### PR TITLE
Sorted old documentation into new 4 part structure in side bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: NeIC SDA
+site_name: NeIC SDA Operations handbook
 extra_css: [css/neic-sda.css]
 markdown_extensions:
   - callouts
@@ -7,13 +7,26 @@ plugins:
 theme:
     name: readthedocs
 nav:
-  - Getting started: setup.md
-  - Database setup: db.md
-  - Deployments and Local Bootstrap: deploy.md
-  - Encryption: encryption.md
-  - Data Submission: submission.md
-  - Interfacing with CEGA: connection.md
-  - Data Retrieval API: dataout.md
-  - SDA-Pipeline: services/pipeline.md
-  - Tests: tests.md
-  - Contributing: CONTRIBUTING.md
+  - Home: 'index.md'
+  - 'Structure':
+      - Getting started: 'setup.md'
+      - 'deploy.md'
+      - Tests: 'tests.md'
+  - 'Communication':
+      - Database setup: 'db.md'
+      - Encryption: 'encryption.md'
+      - Data Submission: 'submission.md'
+      - Interfacing with CEGA: 'connection.md'
+  - 'Services':
+      - SDA-Pipeline: 'services/pipeline.md'
+      - 'services/ingest.md'
+      - 'services/verify.md'
+      - 'services/finalize.md'
+      - 'services/backup.md'
+      - 'services/mapper.md'
+      - Data Retrieval API: 'dataout.md'
+  - 'Guides':
+      - Contributing: 'CONTRIBUTING.md'
+
+
+      


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
The original content of the neic-sda documentation site was resorted into the 4 part structure of the new NeIC SDA Operations handbook site. 

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. This was done reordering the mkdocs.yml file that controls the left side bar, and introducing the 4 part main headlines: Structure, Communication, Services, Guides.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
