### PR TITLE
Aggregate docs from new repo

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -6,7 +6,7 @@ on:
       repository:
         description: 'Repository to aggregate documentation from'
         required: true
-        default: "neicnordic/sda-pipeline"
+        default: "neicnordic/sensitive-data-archive"
 
 jobs:
   build:

--- a/aggregate-mappings.json
+++ b/aggregate-mappings.json
@@ -1,12 +1,12 @@
 {
-    "neicnordic/sda-pipeline": {
-        "cmd/backup/backup.md": "docs/services/backup.md",
-        "cmd/finalize/finalize.md": "docs/services/finalize.md",
-        "cmd/ingest/ingest.md": "docs/services/ingest.md",
-        "cmd/intercept/intercept.md": "docs/services/intercept.md",
-        "cmd/mapper/mapper.md": "docs/services/mapper.md",
-        "cmd/notify/notify.md": "docs/services/notify.md",
-        "cmd/verify/verify.md": "docs/services/verify.md",
-        "cmd/pipeline.md": "docs/services/pipeline.md"
+    "neicnordic/sensitive-data-archive": {
+        "sda-pipeline/cmd/backup/backup.md": "docs/services/backup.md",
+        "sda/cmd/finalize/finalize.md": "docs/services/finalize.md",
+        "sda/cmd/ingest/ingest.md": "docs/services/ingest.md",
+        "sda-pipeline/cmd/intercept/intercept.md": "docs/services/intercept.md",
+        "sda-pipeline/cmd/mapper/mapper.md": "docs/services/mapper.md",
+        "sda-pipeline/cmd/notify/notify.md": "docs/services/notify.md",
+        "sda/cmd/verify/verify.md": "docs/services/verify.md",
+        "sda-pipeline/cmd/pipeline.md": "docs/services/pipeline.md"
     }
 }

--- a/aggregate-mappings.json
+++ b/aggregate-mappings.json
@@ -3,8 +3,8 @@
         "sda-pipeline/cmd/backup/backup.md": "docs/services/backup.md",
         "sda/cmd/finalize/finalize.md": "docs/services/finalize.md",
         "sda/cmd/ingest/ingest.md": "docs/services/ingest.md",
-        "sda-pipeline/cmd/intercept/intercept.md": "docs/services/intercept.md",
-        "sda-pipeline/cmd/mapper/mapper.md": "docs/services/mapper.md",
+        "sda/cmd/intercept/intercept.md": "docs/services/intercept.md",
+        "sda/cmd/mapper/mapper.md": "docs/services/mapper.md",
         "sda-pipeline/cmd/notify/notify.md": "docs/services/notify.md",
         "sda/cmd/verify/verify.md": "docs/services/verify.md",
         "sda-pipeline/cmd/pipeline.md": "docs/services/pipeline.md"

--- a/aggregate-mappings.json
+++ b/aggregate-mappings.json
@@ -1,12 +1,9 @@
 {
     "neicnordic/sensitive-data-archive": {
-        "sda-pipeline/cmd/backup/backup.md": "docs/services/backup.md",
         "sda/cmd/finalize/finalize.md": "docs/services/finalize.md",
         "sda/cmd/ingest/ingest.md": "docs/services/ingest.md",
         "sda/cmd/intercept/intercept.md": "docs/services/intercept.md",
         "sda/cmd/mapper/mapper.md": "docs/services/mapper.md",
-        "sda-pipeline/cmd/notify/notify.md": "docs/services/notify.md",
-        "sda/cmd/verify/verify.md": "docs/services/verify.md",
-        "sda-pipeline/cmd/pipeline.md": "docs/services/pipeline.md"
+        "sda/cmd/verify/verify.md": "docs/services/verify.md"
     }
 }


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [x] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

This PR links the documentation aggregation logic from the `sda-pipeline` to the `sensitive-data-archive` repository. Only docs under `sda/cmd ` are linked here since these correspond to components that are merged in and thus expected to get updates. 

Some notes to keep in mind:
- `backup.md` is no longer needed since in the current version of the stack in `sensitive-data-archive` the `backup` service has been [partially merged](https://github.com/neicnordic/sensitive-data-archive/pull/306) with  `finalize` in a way compliant with the FEGA usecase. This change needs to be addressed in the docs throughout.

- `notify.md` and `pipeline.md` may be added later after they are migrated under `sda/cmd` and updated accordingly.

### Related issues:
Related issue for migration of docs to the `sensitive-data-archive` repo: https://github.com/neicnordic/sensitive-data-archive/pull/399 .

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

Aggregate documentation updates from the `sensitive-data-archive` repository for `ingest`,`verify`,`finalize`,`mapper` and `intercept`.
