### PR TITLE
fix links in sda.md

### DIFF
--- a/aggregate-repositories.sh
+++ b/aggregate-repositories.sh
@@ -31,7 +31,7 @@ do
 
     # add special use case for sda.md links
 
-    sed -i -E 's/cmd\/(.+)\//services\//g' docs/services/sda.md
+    sed -i -E 's#cmd\/(.+)\/#''#g' docs/services/sda.md
     git add docs/services/sda.md
 
     # check if there are any changes


### PR DESCRIPTION
when moving from sensitive-data-archive to neic-sda the links differ in sda.md fix that

