### PR TITLE
schedule doc update as cronjob

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -1,6 +1,8 @@
 name: "Aggregate documentation"
 
 on:
+  schedule:
+    - cron: "0 7 * * 1"
   workflow_dispatch:
     inputs:
       repository:
@@ -19,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - run: bash aggregate-repositories.sh ${{ inputs.repository }}
+      - run: bash aggregate-repositories.sh ${{ inputs.repository || 'neicnordic/sensitive-data-archive' }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
**Related issue(s) and PR(s)**
This PR closes #123 .

**Description**
This will run the doc aggregation workflow weekly as a cronjob while keeping the option to run it manually if needed. 
The workflow at the sensitive data archive that triggers the aggregation  becomes obsolete and will be removed from that repo.

**How to test**
Run manually or wait until Monday morning at 07:00.