### PR TITLE
Use ubuntu-22.04 images in actions

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - run: |
           sudo apt-get install -yq aspell

--- a/.github/workflows/auto-merge-update.yml
+++ b/.github/workflows/auto-merge-update.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.head_ref == 'create-pull-request/patch' }}
     steps:
       - name: Wait other jobs are passed or failed

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: ["3.11"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
       
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
**Description**
This should fix [this](https://github.com/neicnordic/neic-sda/actions/runs/11322714698/job/31483941408) failing action.
Ubuntu 24.04 requires installing python packages in environment. As per advice of github, to avoid such breaking changes, this PR fixes the image used in workflows to ubuntu-22.04 that we know works as before.

**How to test**
Actions work.